### PR TITLE
Ajout des images

### DIFF
--- a/backend/src/controllers/letterController.ts
+++ b/backend/src/controllers/letterController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import Letter from "../models/Letter.js";
 import UserLetter from "../models/UserLetter.js";
-import {v2 as cloudinary} from 'cloudinary'
+import { v2 as cloudinary } from 'cloudinary'
 import { v4 as uuidv4 } from 'uuid';
 import fs from "fs"
 
@@ -9,20 +9,23 @@ class LetterController {
   public async createLetter(req: Request, res: Response): Promise<void> {
     try {
       const { title, content, stamp, receiver_id } = req.body;
-      
+
       //Upload img on cloudinary and generate a random id for it and delete the upload file.
       const img = req.file
       let img_id = "";
       if (img) {
         img_id = uuidv4();
-        await cloudinary.uploader.upload(img.path, {public_id: img_id})
+        await cloudinary.uploader.upload(
+          img.path,
+          { public_id: img_id, type: "private", folder: "catWorld" }
+        )
         fs.unlink(img.path, (err) => {
-            if (err) {
-                console.error("Error when deleting upload file :", err);
-            }
+          if (err) {
+            console.error("Error when deleting upload file :", err);
+          }
         });
       }
-      
+
       const sender_id = (req as any).user._id
       if (!sender_id) {
         res.status(403).json({ message: "Can't create letter, sender is not valid !" });
@@ -93,6 +96,14 @@ class LetterController {
         res.status(404).json({ message: "Letter not found" });
         return;
       }
+      //We sign a private URL for the user.
+      if (letter.img_id) {
+        letter.img_id = cloudinary.url(`/catWorld/${letter.img_id}`, {
+          type: "private",
+          sign_url: true
+        })
+      }
+
       res.status(200).json({ message: "Letter found", letter });
     } catch (error) {
       console.error("Error retrieving letter:", error);
@@ -101,6 +112,8 @@ class LetterController {
   }
 
   public async getUnreadLetters(req: Request, res: Response): Promise<void> {
+    //@TODO : Unread and read letter should return a list of id, not all the letters. 
+    // We don't want to create temporary cloudinary links for each of them, so we should get the info with the showLetter route.
     try {
       const id = (req as any).user._id
       if (!id) {
@@ -125,6 +138,7 @@ class LetterController {
       res.status(500).json({ message: "Error retrieving letter" });
     }
   }
+
   public async getReadLetters(req: Request, res: Response): Promise<void> {
     try {
       const id = (req as any).user._id

--- a/backend/src/controllers/letterController.ts
+++ b/backend/src/controllers/letterController.ts
@@ -164,6 +164,44 @@ class LetterController {
       res.status(500).json({ message: "Error retrieving letter" });
     }
   }
+
+  public async getPrivateImg(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = req.params;
+      if (!id) {
+        res.status(400).json({ message: "Missing letter ID" });
+        return;
+      }
+
+      const letter = await Letter.findById(id);
+
+      if (!letter) {
+        res.status(404).json({ message: "Letter not found" });
+        return;
+      }
+
+      let img_url = "";
+      if (letter.img_id) {
+        //@TODO We should add the image format to database instead of using the cloudinary API to get it.
+        const imgInfo = await cloudinary.api.resource(`catWorld/${letter.img_id}`, {
+          type: "private"
+        })
+        img_url = cloudinary.url(`catWorld/${letter.img_id}`, {
+          type: "private",
+          sign_url: true
+        })
+        img_url = cloudinary.utils.private_download_url(`catWorld/${letter.img_id}`, imgInfo.format, {
+          type: "private",
+          expires_at: Math.floor(Date.now() / 1000) + 60
+        })
+      }
+      res.status(200).json({ message: "Image found", img_url });
+
+    } catch (error) {
+      console.error("Error retrieving letter:", error);
+      res.status(500).json({ message: "Error retrieving letter" });
+    }
+  }
 }
 
 

--- a/backend/src/routes/letterRoutes.ts
+++ b/backend/src/routes/letterRoutes.ts
@@ -23,6 +23,11 @@ letterRoutes.get(
   letterController.showLetter
 );
 letterRoutes.get(
+  "/getImageUrl/:id",
+  authMiddleware,
+  letterController.getPrivateImg
+);
+letterRoutes.get(
   "/getUnreadLetters",
   authMiddleware,
   letterController.getUnreadLetters

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:3001/api/
+CLOUDINARY_NAME=your-name
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "react",
       "version": "0.0.0",
       "dependencies": {
+        "@cloudinary/react": "^1.14.1",
+        "@cloudinary/url-gen": "^1.21.0",
         "@react-three/drei": "^9.121.4",
         "@react-three/fiber": "^8.17.14",
         "@vitejs/plugin-react": "^4.3.4",
@@ -319,6 +321,71 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudinary/html": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary/html/-/html-1.13.2.tgz",
+      "integrity": "sha512-AosYYA3TLz5astKokgAxRwlSNGCe1Z62EdA6vwgV/TrZ5y+yc7uHa9cRkSoi1M8GTA2aZvTWo6E2nxUZhNVpSg==",
+      "dependencies": {
+        "@types/lodash.clonedeep": "^4.5.6",
+        "@types/lodash.debounce": "^4.0.6",
+        "@types/node": "^14.14.10",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.debounce": "^4.0.8",
+        "typescript": "^4.1.2"
+      }
+    },
+    "node_modules/@cloudinary/html/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary/html/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@cloudinary/react": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@cloudinary/react/-/react-1.14.1.tgz",
+      "integrity": "sha512-nELBhpZX5+xzU9pJS1pDHZNGLyuwNxuOqHPV3rheyguBV7h6/TKadM3/f1vs0NPac5g+DnDL7UbQ6PhSjr7j4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/html": "^1.13.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@cloudinary/transformation-builder-sdk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.16.1.tgz",
+      "integrity": "sha512-Mh1qYMkoDxSAzbt0qY9NJaZrdH/vFBcrpeVWmbTXbPVDZHLaaLyJ2+RDFGger5lycbrehPLoNp2hh22BvhkvbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/url-gen": "^1.7.0"
+      }
+    },
+    "node_modules/@cloudinary/url-gen": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.21.0.tgz",
+      "integrity": "sha512-ctYcCzX3G3vcgnESTU2ET3K1XsBiXcEnBddCGV0QbR3fJhLLrIShjSMEwZoepgh4LAFOHJu9DzvLFr+E8R7c7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/transformation-builder-sdk": "^1.15.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1880,6 +1947,41 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
@@ -3752,6 +3854,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5027,6 +5141,14 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "@cloudinary/react": "^1.14.1",
+    "@cloudinary/url-gen": "^1.21.0",
     "@react-three/drei": "^9.121.4",
     "@react-three/fiber": "^8.17.14",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/public/style/pages/ShowLetter.scss
+++ b/frontend/public/style/pages/ShowLetter.scss
@@ -2,7 +2,7 @@
     width: 100dvw;
     height: 100dvh;
     max-width: 768px;
-    padding: 0 12px 0 12px;
+    padding: 1rem;
     background-color: #F5EDFE;
     p{
         text-wrap: wrap;
@@ -30,15 +30,12 @@
     }
 
     .content{
-        margin-bottom: 50%;
         animation: 1s ease-in-out 0s 1 slideInFromBottom;
         position: relative;
-        width: 100%;
         height: 100%;
-        padding: 45px;
-
-
-        
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
 
     .letterHeader{
@@ -60,20 +57,16 @@
         width: 90%;
         height: 90%;
         object-fit: cover;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
     }
 
     .letterContent {
-        z-index: 1;
         position: absolute;
-        padding: 87px 27px 0px 27px;
-        height: 90%;
-        width: 80%;
+        height: 100%;
+        width: 75%;
         display: flex;
         flex-direction: column;
         gap: 24px;
+        padding-top: 3rem;
         color: black;
     }
 
@@ -82,22 +75,22 @@
     }
 }
 
-.letterInformation{
+.letterInformation {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: start;
     align-items: start;
     width: 100%;
 }
 
 .btnWhiteShowLetter{
-    max-width: 768px;
-    width: 80%;
-    left: 50%;
-    top: 100%;
-    position: absolute;
-    z-index: 14;
-    transform: translate(-50%, -150%);
+    // max-width: 768px;
+    // width: 80%;
+    // left: 50%;
+    // top: 100%;
+    // position: absolute;
+    // z-index: 14;
+    // transform: translate(0, 50%);
 }
 
 @keyframes slideInFromBottom {
@@ -115,5 +108,17 @@
     }
     100% {
         transform: translateY(-300%);
+    }
+}
+
+.letterFooter {
+    display: flex;
+    justify-content: space-between;
+    transform: translate(0, 10%);
+    
+    img {
+        background-color: #FFF9EF;
+        padding: .5rem .5em 2rem .5rem;
+        width: 110px;
     }
 }

--- a/frontend/public/style/pages/ShowLetter.scss
+++ b/frontend/public/style/pages/ShowLetter.scss
@@ -4,6 +4,12 @@
     max-width: 768px;
     padding: 1rem;
     background-color: #F5EDFE;
+
+    .letterContainerContent {
+        max-height: 35dvh;
+        overflow: scroll;
+    }
+
     p{
         text-wrap: wrap;
     }
@@ -66,7 +72,7 @@
         display: flex;
         flex-direction: column;
         gap: 24px;
-        padding-top: 3rem;
+        padding-top: 2rem;
         color: black;
     }
 
@@ -119,6 +125,12 @@
     img {
         background-color: #FFF9EF;
         padding: .5rem .5em 2rem .5rem;
-        width: 110px;
+        width: 160px;
     }
+}
+
+.letterFooterWithoutImage {
+    transform: translate(0, 0);
+    padding-bottom: 2rem;
+    justify-content: end;
 }

--- a/frontend/public/style/pages/createLetter.scss
+++ b/frontend/public/style/pages/createLetter.scss
@@ -1,7 +1,7 @@
 .createLetterContainer {
     background-color: #F5EDFE;
     height: 100dvh;
-    padding: 12px;
+    padding: 1rem;
 
     h1 {
         padding-left: 2.75rem;
@@ -18,16 +18,12 @@
     }
 
     .letterContentForm {
-        z-index: 1;
         position: absolute;
-        padding: 0px 27px 0px 27px;
+        padding: 0px 27px;
         width: 100%;
-        height: 95%;
     }
 
     .letterBackground {
-        z-index: 0;
-        position: absolute;
         object-fit: cover;
         width: 100%;
         height: 100%;
@@ -35,11 +31,10 @@
 
     .letterHeader{
         display: flex;
-        justify-content: start;
-        align-items: center;
-        gap: 12px;
+        gap: 1rem;
         width: 100%;
     }
+
     .buttonStamp{
         background-color: #E6D0AC;
         border: #79633E 1px dashed;
@@ -108,12 +103,13 @@
 .letterBody{
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: .5rem;
     height: 100%;
+
     div{
         display: flex;
         flex-direction: column;
-        justify-content: start;
+        
         input, textarea{
             background-color: unset;
             border: 0px;
@@ -127,10 +123,6 @@
             padding-left:12px ;
         }
     }
-}
-
-.letterContainerContent{
-    height: 100%;
 }
 
 .senderText{

--- a/frontend/public/style/pages/createLetter.scss
+++ b/frontend/public/style/pages/createLetter.scss
@@ -12,10 +12,6 @@
         color: #000000;
     }
 
-    .sendButton {
-        background-color: white;
-    }
-
     .letter {
         position: relative;
         height: 70%;
@@ -170,17 +166,39 @@
     overflow: hidden;
 }
 
+.addImageContainer {
+    background-color: #FFF9EF;
+    padding: .5rem .5em 2rem .5rem;
+}
+
 .sendContainer {
     display: flex;
+    align-items: start;
+    justify-content: space-between;
 
     .imageInput {
         background-color: #E6D0AC;
         border: #79633E 1px dashed;
-        min-width: 70px;
-        min-height: 78px;
-        padding: 0;
+        padding: .5rem;
+        width: 110px;
         border-radius: 8px;
         display: flex;
         flex-direction: column;
+        align-items: center;
+    }
+
+    .importImage {
+        width: 16px;
+    }
+
+    .sendButton {
+        background-color: white;
+        margin-left: 1rem;
+        padding: 0.25rem 2em 0.25rem 2rem;
+        border-radius: 3rem;
+    }
+
+    p {
+        text-align: center;
     }
 }

--- a/frontend/public/style/pages/createLetter.scss
+++ b/frontend/public/style/pages/createLetter.scss
@@ -21,6 +21,7 @@
         position: absolute;
         padding: 0px 27px;
         width: 100%;
+        height: 100%;
     }
 
     .letterBackground {

--- a/frontend/public/style/pages/createLetter.scss
+++ b/frontend/public/style/pages/createLetter.scss
@@ -133,7 +133,7 @@
     height: 100%;
 }
 
-.usernameContent{
+.senderText{
     text-align: end;
 }
 

--- a/frontend/public/style/pages/createLetter.scss
+++ b/frontend/public/style/pages/createLetter.scss
@@ -1,4 +1,4 @@
-.containerCreateLetter {
+.createLetterContainer {
     background-color: #F5EDFE;
     height: 100dvh;
     padding: 12px;
@@ -21,7 +21,7 @@
         height: 70%;
     }
 
-    .letterContent {
+    .letterContentForm {
         z-index: 1;
         position: absolute;
         padding: 0px 27px 0px 27px;
@@ -96,7 +96,7 @@
     align-items: start;
     width: 100%;
 }
-.selectRecever{
+.selectReceiver{
     display: flex;
     gap: 4px;
     width: 100%;
@@ -124,7 +124,7 @@
             border-radius: 0%;
             border-bottom: 1px solid black;
         }
-        .contenuletter{
+        .letterContentText{
             height: 100%;
             min-height: 132px;
             resize : none;
@@ -133,11 +133,11 @@
     }
 }
 
-.contenuLetterContainer{
+.letterContainerContent{
     height: 100%;
 }
 
-.usernameContenue{
+.usernameContent{
     text-align: end;
 }
 
@@ -164,10 +164,23 @@
     transform: translateY(0); 
 }
 
-.pagecreateletter{
+.createLetterPage{
     width: 100%;
     height: fit-content;
     overflow: hidden;
 }
 
+.sendContainer {
+    display: flex;
 
+    .imageInput {
+        background-color: #E6D0AC;
+        border: #79633E 1px dashed;
+        min-width: 70px;
+        min-height: 78px;
+        padding: 0;
+        border-radius: 8px;
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/frontend/public/style/reset.scss
+++ b/frontend/public/style/reset.scss
@@ -105,7 +105,9 @@ h2,
 h3,
 h4,
 h5,
-p {
+p,
+textarea
+ {
     margin: 0;
     padding: 0;
     border: 0;

--- a/frontend/src/config/route.ts
+++ b/frontend/src/config/route.ts
@@ -17,6 +17,7 @@ const apiRoutes = {
     status: "auth/status/",
     sendLetter: "letter/createletter/",
     showLetter: "letter/showletter/",
+    getLetterImage: "letter/getImageUrl/",
     updateRead: "userLetter/updateUserLetter/",
     fetchLetterRead: "letter/getReadLetters/",
     fetchLetterUnread: "letter/getUnreadLetters/",

--- a/frontend/src/pages/CreateLetter.tsx
+++ b/frontend/src/pages/CreateLetter.tsx
@@ -18,8 +18,8 @@ const initialFormData = {
 const CreateLetter = () => {
 
     const [hasSubmitted, setHasSubmitted] = useState(false);
-    const [image, setImage] = useState<string>("");
     const [stampError, setStampError] = useState<string>("");
+    const [image, setImage] = useState<File>();
     const [showValidation, setShowValidation] = useState(false);
     const [formData, setFormData] = useState(initialFormData);
     const [showStamps, setShowStamps] = useState(false);
@@ -145,6 +145,7 @@ const CreateLetter = () => {
         if (e.target.type === "file") {
             const fileInput = e.target as HTMLInputElement;
             if (fileInput.files && fileInput.files[0]) {
+                setImage(fileInput.files[0])
                 setFormData({ ...formData, src_img: fileInput.files[0] });
             }
         }
@@ -234,18 +235,20 @@ const CreateLetter = () => {
                             </div>
                             <p className="usernameContent">{user?.username}</p>
                             <div className="sendContainer">
-                                {
-                                    image ?
-                                        <img src={`${image}`} alt="" />
-                                    :
-                                        <div className="addImageContainer">
-                                            <label  className="imageInput" htmlFor="image">
-                                                <img src="/image/icons/import.svg" />
-                                                Ajouter une image
-                                            </label>
-                                            <input style={{display:"none"}} placeholder="mon image" title="choisir une image" id="image" type='file' name="image" accept="image/*" onChange={handleChange} required />
-                                        </div>
-                                }
+                                <div className="addImageContainer">
+                                    <label htmlFor="image">
+                                        {
+                                            image ?
+                                                <img className="imageInput" src={URL.createObjectURL(image)} alt="letter selected image" />
+                                                :
+                                                <div className="imageInput">
+                                                    <img className="importImage" src="/image/icons/import.svg" />
+                                                    <p>Ajouter une image</p>
+                                                </div>
+                                        }
+                                    </label>
+                                    <input style={{ display: "none" }} placeholder="mon image" title="choisir une image" id="image" type='file' name="image" accept="image/*" onChange={handleChange} />
+                                </div>
                                 <button className="sendButton" type="submit"><p>Envoyer</p></button>
                             </div>
                         </form>

--- a/frontend/src/pages/CreateLetter.tsx
+++ b/frontend/src/pages/CreateLetter.tsx
@@ -18,7 +18,7 @@ const initialFormData = {
 const CreateLetter = () => {
 
     const [hasSubmitted, setHasSubmitted] = useState(false);
-    const [image, setImage] = useState(Image);
+    const [image, setImage] = useState<string>("");
     const [stampError, setStampError] = useState<string>("");
     const [showValidation, setShowValidation] = useState(false);
     const [formData, setFormData] = useState(initialFormData);
@@ -115,9 +115,6 @@ const CreateLetter = () => {
 
             const response = await fetch(import.meta.env.VITE_API_URL + apiRoutes.sendLetter, {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
                 body: formDataToSend,
                 credentials: "include"
             });
@@ -182,16 +179,15 @@ const CreateLetter = () => {
 
     return (
         <>
-            <div className="pagecreateletter">
-
+            <div className="createLetterPage">
                 <NavBar />
-                <div className="containerCreateLetter">
+                <div className="createLetterContainer">
                     <h1>Ma lettre</h1>
                     <div className="letter">
                         {message && <p>{message}</p>}
                         <img className="letterBackground" src="/image/letters/letter-background.svg" alt="letter background" />
 
-                        <form className="letterContent" onSubmit={handleSubmit}>
+                        <form className="letterContentForm" onSubmit={handleSubmit}>
                             <div className="letterHeader">
                                 <button className="buttonStamp" type="button" onClick={() => setShowStamps(!showStamps)}>
                                     {formData.stamp && formData.stamp !== "test" ? (
@@ -201,10 +197,10 @@ const CreateLetter = () => {
                                             alt="chosen stamp"
                                         />
                                     ) : (
-                                        <div className="addStamp">
+                                        <>
                                             <img src="/image/icons/import.svg" />
                                             <p>Ajouter un timbre</p>
-                                        </div>
+                                        </>
                                     )}
                                 </button>
                                 {hasSubmitted && stampError && (
@@ -214,7 +210,7 @@ const CreateLetter = () => {
                                 )}
                                 <div className="letterInformation">
                                     <p className="username">De : {user?.username}</p>
-                                    <div className="selectRecever">
+                                    <div className="selectReceiver">
                                         <p className="receiver"> À :  </p>
                                         <select name="receiver_id" id="receiver-select" onChange={handleChange} value={formData.receiver_id} required>
                                             <option value="">Choisis un(e) ami(e)</option>
@@ -231,18 +227,25 @@ const CreateLetter = () => {
                                     <label htmlFor="send-letter">Titre</label>
                                     <input id="title" type='text' name="title" placeholder="Ma lettre" onChange={handleChange} value={formData.title} required />
                                 </div>
-                                <div className="contenuLetterContainer">
+                                <div className="letterContainerContent">
                                     <label htmlFor="send-letter">Contenu</label>
-                                    <textarea className="contenuletter" id="content" name="content" placeholder="Cher ami..." onChange={handleChange} value={formData.content} required />
+                                    <textarea className="letterContentText" id="content" name="content" placeholder="Cher ami..." onChange={handleChange} value={formData.content} required />
                                 </div>
                             </div>
-                            <p className="usernameContenue">{user?.username}</p>
-                            <div>
+                            <p className="usernameContent">{user?.username}</p>
+                            <div className="sendContainer">
                                 {
-                                    image && 
-                                    <img src={`${image}`} alt="" />
+                                    image ?
+                                        <img src={`${image}`} alt="" />
+                                    :
+                                        <div className="addImageContainer">
+                                            <label  className="imageInput" htmlFor="image">
+                                                <img src="/image/icons/import.svg" />
+                                                Ajouter une image
+                                            </label>
+                                            <input style={{display:"none"}} placeholder="mon image" title="choisir une image" id="image" type='file' name="image" accept="image/*" onChange={handleChange} required />
+                                        </div>
                                 }
-                                <input id="image" type='file' name="image" accept="image/*" onChange={handleChange} required></input>
                                 <button className="sendButton" type="submit"><p>Envoyer</p></button>
                             </div>
                         </form>

--- a/frontend/src/pages/CreateLetter.tsx
+++ b/frontend/src/pages/CreateLetter.tsx
@@ -225,15 +225,15 @@ const CreateLetter = () => {
                             </div>
                             <div className="letterBody">
                                 <div>
-                                    <label htmlFor="send-letter">Titre</label>
+                                    <label htmlFor="title">Titre</label>
                                     <input id="title" type='text' name="title" placeholder="Ma lettre" onChange={handleChange} value={formData.title} required />
                                 </div>
                                 <div className="letterContainerContent">
-                                    <label htmlFor="send-letter">Contenu</label>
+                                    <label htmlFor="content">Contenu</label>
                                     <textarea className="letterContentText" id="content" name="content" placeholder="Cher ami..." onChange={handleChange} value={formData.content} required />
                                 </div>
                             </div>
-                            <p className="usernameContent">{user?.username}</p>
+                            <p className="senderText">{user?.username}</p>
                             <div className="sendContainer">
                                 <div className="addImageContainer">
                                     <label htmlFor="image">

--- a/frontend/src/pages/Letters.tsx
+++ b/frontend/src/pages/Letters.tsx
@@ -16,7 +16,8 @@ const Letters = () => {
         navigate(routes.createLetter);
     }
 
-    const handleShowLetter = () => {
+    const handleShowLetter = async () => {
+
         if (!unreadLetters) {
             return;
         }
@@ -49,11 +50,11 @@ const Letters = () => {
             } else if (count < 10) {
                 setUnreadNumber(5);
             } else if (count < 15) {
-                setReadNumber(10);
+                setUnreadNumber(10);
             } else if (count < 25) {
-                setReadNumber(15);
+                setUnreadNumber(15);
             } else {
-                setReadNumber(25);
+                setUnreadNumber(25);
             }
 
         } catch (error) {

--- a/frontend/src/pages/ShowLetter.tsx
+++ b/frontend/src/pages/ShowLetter.tsx
@@ -97,11 +97,11 @@ const ShowLetter = () => {
                                 <div>
                                     <p className="titleContent">{letter.letter_id.title}</p>
                                 </div>
-                                <div className="contenuLetterContainer">
+                                <div className="letterContainerContent">
                                     <p>{letter.letter_id.content}</p>
                                 </div>
                             </div>
-                            <p className="usernameContenue">{letter.sender_id.username}</p>
+                            <p className="usernameContent">{letter.sender_id.username}</p>
                         </div>
                         <ButtonRound
                             text="Retourner à mon bureau"

--- a/frontend/src/pages/ShowLetter.tsx
+++ b/frontend/src/pages/ShowLetter.tsx
@@ -119,7 +119,7 @@ const ShowLetter = () => {
                                     <p>{letter.letter_id.content}</p>
                                 </div>
                             </div>
-                            <div className="letterFooter">
+                            <div className={`letterFooter ${!letterImage ? "letterFooterWithoutImage" : ""}`}>
                                 {
                                     letterImage &&
                                     <img src={letterImage} alt="image sent by your friend" />

--- a/frontend/src/pages/ShowLetter.tsx
+++ b/frontend/src/pages/ShowLetter.tsx
@@ -17,13 +17,14 @@ interface Letter {
     content: string,
     stamp: string,
     sender: string
-    img_id: string
+    _id: string
 }
 
 const ShowLetter = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const letter: { _id: string, sender_id: User, createdAt: string, letter_id: Letter, read: boolean } = location.state?.letter;
+    const [letterImage, setLetterImage] = useState<string | null>(null);
     const [showLetter, setShowLetter] = useState(false);
     const [isExiting, setIsExiting] = useState(false);
     const [showContent, setShowContent] = useState(false)
@@ -55,9 +56,28 @@ const ShowLetter = () => {
         await updateRead(true)
     }
 
+    const handleShowLetter = async () => {
+        try {
+            const response = await fetch(
+                import.meta.env.VITE_API_URL + apiRoutes.getLetterImage + letter.letter_id._id,
+                {
+                    method: "GET",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    credentials: "include",
+                }
+            );
+            console.log(response)
+            if (response.ok) {
+                const data = await response.json()
+                setLetterImage(data.img_url);
+            }
+        }
+        catch (error) {
+            console.error(error)
+        }
 
-
-    const handleShowLetter = () => {
         setShowLetter(true);
         setTimeout(() => {
             setIsExiting(true)
@@ -101,19 +121,19 @@ const ShowLetter = () => {
                             </div>
                             <div className="letterFooter">
                                 {
-                                    letter.letter_id.img_id &&
-                                    <img src={letter.letter_id.img_id} alt="image sent by your friend" />
+                                    letterImage &&
+                                    <img src={letterImage} alt="image sent by your friend" />
                                 }
                                 <p className="senderText">{letter.sender_id.username}</p>
                             </div>
-                        </div>
-                        <ButtonRound
-                            text="Retourner à mon bureau"
+                            <ButtonRound
+                                text="Retourner à mon bureau"
 
-                            hasBackground
-                            customClassName="btnWhiteShowLetter"
-                            onClick={handleBacktoDesk}
-                        />
+                                hasBackground
+                                customClassName="btnWhiteShowLetter"
+                                onClick={handleBacktoDesk}
+                            />
+                        </div>
                     </div>
 
                     : //Or

--- a/frontend/src/pages/ShowLetter.tsx
+++ b/frontend/src/pages/ShowLetter.tsx
@@ -17,7 +17,7 @@ interface Letter {
     content: string,
     stamp: string,
     sender: string
-
+    img_id: string
 }
 
 const ShowLetter = () => {
@@ -28,7 +28,6 @@ const ShowLetter = () => {
     const [isExiting, setIsExiting] = useState(false);
     const [showContent, setShowContent] = useState(false)
     const formattedDate = new Intl.DateTimeFormat('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' }).format(new Date(letter.createdAt));
-
 
     const updateRead = async (newRead: boolean) => {
         try {
@@ -46,7 +45,6 @@ const ShowLetter = () => {
             if (response.ok) {
                 navigate("/letters");
             }
-
         }
         catch (error) {
             console.error(error)
@@ -101,7 +99,13 @@ const ShowLetter = () => {
                                     <p>{letter.letter_id.content}</p>
                                 </div>
                             </div>
-                            <p className="usernameContent">{letter.sender_id.username}</p>
+                            <div className="letterFooter">
+                                {
+                                    letter.letter_id.img_id &&
+                                    <img src={letter.letter_id.img_id} alt="image sent by your friend" />
+                                }
+                                <p className="senderText">{letter.sender_id.username}</p>
+                            </div>
                         </div>
                         <ButtonRound
                             text="Retourner à mon bureau"


### PR DESCRIPTION
Lien avec Cloudinary pour ajouter des images.

Les images sont stockées en ligne sur un serveur cloudinary. leur public id est ensuite stocké dans la base de donnée. Lors du chargement, le backend génère un URL privé qui donne accès à l'image pendant quelques minutes. Cela permet d'éviter que des sources externes connaissant la nom du stockage cloudinary y ait accès

Il manque :

- [ ] Ajouter le format en base de données pour limiter les requêtes API
- [ ] Changer la façon de récupérer les lettres. 

Actuellement, on récupère les lettres ainsi que leurs contenu et les utilisateurs quand on fait getunreadLetters. Si on suit cette logique, on devrait créer des url privées pour toute les lettres pour ne pas avoir à faire une nouvelle requête API pour showLetter. Cela n'est pas viable car le nombre de requêtes à cloudinary exploserait. Il faudrait mieux que getunread letters renvoie uniquement les ID des lettres et les retourne (on a besoin que du nombre de lettres non lue sur la page letters). Ensuite, la requête showLetter renvoie les informations nécessaires, en les fetchant à partir de l'id de la lettre et de l'utilisateur qui fait la requête.

Je ferai la PR et corrigerai tout ça dans une autre branche dédiée, histoire d'avancer cette feature et de vérifier si le css fonctionne en prod.